### PR TITLE
fixed TWAR address format

### DIFF
--- a/I2C_slave.c
+++ b/I2C_slave.c
@@ -6,7 +6,7 @@
 
 void I2C_init(uint8_t address){
 	// load address into TWI address register
-	TWAR = address;
+	TWAR = (address << 1);
 	// set the TWCR to enable address matching and enable TWI, clear TWINT, enable TWI interrupt
 	TWCR = (1<<TWIE) | (1<<TWEA) | (1<<TWINT) | (1<<TWEN);
 }


### PR DESCRIPTION
Added a shift by 1, as described by Atmel-8271J-AVR-ATmega-Datasheet_11/2015 (p. 223). Without it example code with address 0x32 turns out as 0x19.